### PR TITLE
UART: fix bug in baudrate->BRR

### DIFF
--- a/drv/stm32cube/bsp_uart.c
+++ b/drv/stm32cube/bsp_uart.c
@@ -302,7 +302,7 @@ uint32_t bsp_uart_get_final_baudrate(bsp_dev_uart_t dev_num)
 
 		final_baudrate = brr >> 4;
 		if(final_baudrate > 0) {
-			f_baudrate_frac = (float)(brr & 0x0F) / 16.0f;
+			f_baudrate_frac = (float)(brr & 0x07) / 8.0f;
 			f_baudrate = ((float)final_baudrate) + f_baudrate_frac;
 			final_baudrate = (uint32_t)((float)clock / f_baudrate);
 		}
@@ -315,7 +315,7 @@ uint32_t bsp_uart_get_final_baudrate(bsp_dev_uart_t dev_num)
 
 		final_baudrate = brr >> 4;
 		if(final_baudrate > 0) {
-			f_baudrate_frac = (float)(brr & 0x07) / 8.0f;
+			f_baudrate_frac = (float)(brr & 0x0F) / 16.0f;
 			f_baudrate = ((float)final_baudrate) + f_baudrate_frac;
 			final_baudrate = (uint32_t)((float)clock / f_baudrate);
 		}

--- a/drv/stm32cube/inc/stm32f4xx_hal_uart.h
+++ b/drv/stm32cube/inc/stm32f4xx_hal_uart.h
@@ -548,8 +548,8 @@ typedef struct
 
 #define __DIV_SAMPLING8(_PCLK_, _BAUD_)             (((_PCLK_)*25)/(2*(_BAUD_)))
 #define __DIVMANT_SAMPLING8(_PCLK_, _BAUD_)         (__DIV_SAMPLING8((_PCLK_), (_BAUD_))/100)
-#define __DIVFRAQ_SAMPLING8(_PCLK_, _BAUD_)         (((__DIV_SAMPLING8((_PCLK_), (_BAUD_)) - (__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) * 100)) * 16 + 50) / 100)
-#define __UART_BRR_SAMPLING8(_PCLK_, _BAUD_)        ((__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) << 4)|(__DIVFRAQ_SAMPLING8((_PCLK_), (_BAUD_)) & 0x0F))
+#define __DIVFRAQ_SAMPLING8(_PCLK_, _BAUD_)         (((__DIV_SAMPLING8((_PCLK_), (_BAUD_)) - (__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) * 100)) * 8 + 50) / 100)
+#define __UART_BRR_SAMPLING8(_PCLK_, _BAUD_)        ((__DIVMANT_SAMPLING8((_PCLK_), (_BAUD_)) << 4)|(__DIVFRAQ_SAMPLING8((_PCLK_), (_BAUD_)) & 0x07))
 
 #define IS_UART_BAUDRATE(BAUDRATE) ((BAUDRATE) < 10500001)
 #define IS_UART_ADDRESS(ADDRESS) ((ADDRESS) <= 0xF)                             


### PR DESCRIPTION
Some UART speeds were incorrectly set and reported.

Source:
STM32F405 reference manual
30.3.4 page 965:

USARTDIV is an unsigned fixed point number that is coded on the
USART_BRR register.
Note:
• When OVER8=0, the fractional part is coded on 4 bits and programmed by the
DIV_fraction[3:0] bits in the USART_BRR register
• When OVER8=1, the fractional part is coded on 3 bits and programmed by the
DIV_fraction[2:0] bits in the USART_BRR register, and bit
DIV_fraction[3] must be kept
cleared.
