### PR TITLE
software JTAG mode

### DIFF
--- a/common/exec.c
+++ b/common/exec.c
@@ -240,6 +240,7 @@ static struct cmd_map {
 	{ T_PWM, cmd_pwm },
 	{ T_GPIO, cmd_gpio },
 	{ T_SUMP, cmd_sump },
+	{ T_JTAG, cmd_mode_init },
 	{ 0, NULL }
 };
 

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -113,6 +113,16 @@ t_token_dict tl_dict[] = {
 	{ T_DUTY_CYCLE, "duty-cycle" },
 	{ T_BRIDGE, "bridge" },
 	{ T_SUMP, "sump" },
+	{ T_JTAG, "jtag" },
+	{ T_TCK, "tck" },
+	{ T_TMS, "tms" },
+	{ T_TDI, "tdi" },
+	{ T_TDO, "tdo" },
+	{ T_QUERY, "query" },
+	{ T_BRUTE, "brute" },
+	{ T_BYPASS, "bypass" },
+	{ T_IDCODE, "idcode" },
+	{ T_OOCD, "openocd" },
 
 	{ T_LEFT_SQ, "[" },
 	{ T_RIGHT_SQ, "]" },
@@ -183,6 +193,20 @@ t_token tokens_mode_nfc_scan[] = {
 	{
 		T_CONTINUOUS,
 		.help = "Scan until interrupted"
+	},
+	{ }
+};
+
+t_token tokens_mode_brute[] = {
+	{
+		T_BYPASS,
+		.arg_type = T_ARG_INT,
+		.help = "Performs a BYPASS scan on n pins"
+	},
+	{
+		T_IDCODE,
+		.arg_type = T_ARG_INT,
+		.help = "Performs an IDCODE scan on n pins"
 	},
 	{ }
 };
@@ -480,6 +504,134 @@ t_token tokens_mode_spi[] = {
 
 t_token tokens_spi[] = {
 	SPI_PARAMETERS
+	{ }
+};
+
+#define JTAG_PARAMETERS \
+	{ T_DEVICE, \
+		.arg_type = T_ARG_INT, \
+		.help = "JTAG device (1)" }, \
+	{ T_PULL, \
+		.arg_type = T_ARG_TOKEN, \
+		.subtokens = tokens_gpio_pull, \
+		.help = "GPIO pull (up/down/floating)" },
+
+t_token tokens_mode_jtag[] = {
+	{
+		T_SHOW,
+		.subtokens = tokens_mode_show,
+		.help = "Show JTAG parameters"
+	},
+	JTAG_PARAMETERS
+	/* JTAG-specific commands */
+	{
+		T_READ,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>)"
+	},
+	{
+		T_WRITE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_ARG_INT,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_TCK,
+		.arg_type = T_ARG_INT, \
+		.help = "Set TCK pin number x for PBx"
+	},
+	{
+		T_TMS,
+		.arg_type = T_ARG_INT, \
+		.help = "Set TMS pin number x for PBx"
+	},
+	{
+		T_TDI,
+		.arg_type = T_ARG_INT, \
+		.help = "Set TDI pin number x for PBx"
+	},
+	{
+		T_TDO,
+		.arg_type = T_ARG_INT, \
+		.help = "Set TDO pin number x for PBx"
+	},
+	{
+		T_BRUTE,
+        .subtokens = tokens_mode_brute,
+		.help = "Bruteforce JTAG pins on x pins starting from PC0"
+	},
+	{
+		T_BYPASS,
+		.help = "Query number of devices in the JTAG chain using BYPASS mode"
+	},
+	{
+		T_IDCODE,
+		.help = "Scan for IDCODEs in the JTAG chain"
+	},
+	{
+		T_OOCD,
+		.help = "Get into OpenOCD mode"
+	},
+	/* BP commands */
+	{
+		T_CARET,
+		.help = "Send one clock tick"
+	},
+	{
+		T_SLASH,
+		.help = "Toggle clock level high"
+	},
+	{
+		T_BACKSLASH,
+		.help = "Toggle clock level low"
+	},
+	{
+		T_MINUS,
+		.help = "Toggle TDI high"
+	},
+	{
+		T_UNDERSCORE,
+		.help = "Toggle TDI low"
+	},
+	{
+		T_LEFT_SQ,
+		.help = "Toggle TMS high"
+	},
+	{
+		T_RIGHT_SQ,
+		.help = "Toggle TMS low"
+	},
+	{
+		T_EXCLAMATION,
+		.help = "Read bit with clock"
+	},
+	{
+		T_DOT,
+		.help = "Read bit without clock"
+	},
+	{
+		T_AMPERSAND,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Delay 1 usec (repeat with :<num>)"
+	},
+	{
+		T_PERCENT,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Delay 1 msec (repeat with :<num>)"
+	},
+	{
+		T_EXIT,
+		.help = "Exit JTAG mode"
+	},
+	{ }
+};
+
+t_token tokens_jtag[] = {
+	JTAG_PARAMETERS
 	{ }
 };
 
@@ -822,6 +974,11 @@ t_token tl_tokens[] = {
 	{
 		T_SUMP,
 		.help = "SUMP mode"
+	},
+	{
+		T_JTAG,
+		.subtokens = tokens_jtag,
+		.help = "JTAG mode"
 	},
 	{
 		T_DEBUG,

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -105,7 +105,17 @@ enum {
 	T_PWM,
 	T_DUTY_CYCLE,
 	T_BRIDGE,
-    T_SUMP,
+	T_SUMP,
+	T_JTAG,
+	T_TCK,
+	T_TMS,
+	T_TDI,
+	T_TDO,
+	T_QUERY,
+	T_BRUTE,
+	T_BYPASS,
+	T_IDCODE,
+	T_OOCD,
 
 	/* BP-compatible commands */
 	T_LEFT_SQ,

--- a/hydrabus/hydrabus.mk
+++ b/hydrabus/hydrabus.mk
@@ -9,6 +9,7 @@ HYDRABUSSRC = hydrabus/hydrabus.c \
             hydrabus/hydrabus_mode_spi.c \
             hydrabus/hydrabus_mode_uart.c \
             hydrabus/hydrabus_mode_i2c.c \
-            hydrabus/hydrabus_sump.c
+            hydrabus/hydrabus_sump.c \
+            hydrabus/hydrabus_mode_jtag.c
 # Required include directories
 HYDRABUSINC = ./hydrabus

--- a/hydrabus/hydrabus_mode.c
+++ b/hydrabus/hydrabus_mode.c
@@ -37,10 +37,12 @@ extern const mode_exec_t mode_spi_exec;
 extern const mode_exec_t mode_i2c_exec;
 extern const mode_exec_t mode_uart_exec;
 extern const mode_exec_t mode_nfc_exec;
+extern const mode_exec_t mode_jtag_exec;
 extern t_token tokens_mode_spi[];
 extern t_token tokens_mode_i2c[];
 extern t_token tokens_mode_uart[];
 extern t_token tokens_mode_nfc[];
+extern t_token tokens_mode_jtag[];
 
 static struct {
 	int token;
@@ -51,6 +53,7 @@ static struct {
 	{ T_I2C, tokens_mode_i2c, &mode_i2c_exec },
 	{ T_UART, tokens_mode_uart, &mode_uart_exec },
 	{ T_NFC, tokens_mode_nfc, &mode_nfc_exec },
+	{ T_JTAG, tokens_mode_jtag, &mode_jtag_exec },
 };
 
 const char hydrabus_mode_str_cs_enabled[] =  "/CS ENABLED\r\n";

--- a/hydrabus/hydrabus_mode_jtag.c
+++ b/hydrabus/hydrabus_mode_jtag.c
@@ -1,0 +1,746 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2012-2014 Benjamin VERNOUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hydrabus_mode_jtag.h"
+#include "bsp_gpio.h"
+#include "stm32f4xx_hal.h"
+#include <string.h>
+
+static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
+static int show(t_hydra_console *con, t_tokenline_parsed *p);
+static void clkh(t_hydra_console *con);
+static void clkl(t_hydra_console *con);
+static void dath(t_hydra_console *con);
+static void datl(t_hydra_console *con);
+static void clk(t_hydra_console *con);
+
+static jtag_config config;
+
+static const char* str_prompt_jtag[] = {
+	"jtag1" PROMPT,
+};
+
+static void init_proto_default(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	/* Defaults */
+	proto->dev_num = 0;
+	proto->dev_gpio_mode = MODE_CONFIG_DEV_GPIO_OUT_PUSHPULL;
+	proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_NOPULL;
+
+	config.tdi_pin = 8;
+	config.tdo_pin = 9;
+	config.tms_pin = 10;
+	config.tck_pin = 11;
+}
+
+static void show_params(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	cprintf(con, "Device: JTAG%d\r\n",
+		proto->dev_num + 1);
+}
+
+static bool jtag_pin_init(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+    if(config.tck_pin == config.tms_pin) return false;
+    if(config.tck_pin == config.tdi_pin) return false;
+    if(config.tck_pin == config.tdo_pin) return false;
+    if(config.tms_pin == config.tdi_pin) return false;
+    if(config.tms_pin == config.tdo_pin) return false;
+    if(config.tdi_pin == config.tdo_pin) return false;
+
+	bsp_gpio_init(BSP_GPIO_PORTB, config.tdi_pin,
+			proto->dev_gpio_mode, proto->dev_gpio_pull);
+	bsp_gpio_init(BSP_GPIO_PORTB, config.tdo_pin,
+			MODE_CONFIG_DEV_GPIO_IN, proto->dev_gpio_pull);
+	bsp_gpio_init(BSP_GPIO_PORTB, config.tms_pin,
+			proto->dev_gpio_mode, proto->dev_gpio_pull);
+	bsp_gpio_init(BSP_GPIO_PORTB, config.tck_pin,
+			proto->dev_gpio_mode, proto->dev_gpio_pull);
+    return true;
+}
+
+static inline void jtag_tms_high(void)
+{
+	bsp_gpio_set(BSP_GPIO_PORTB, config.tms_pin);
+}
+
+static inline void jtag_tms_low(void)
+{
+	bsp_gpio_clr(BSP_GPIO_PORTB, config.tms_pin);
+}
+
+static inline void jtag_clk_high(void)
+{
+	bsp_gpio_set(BSP_GPIO_PORTB, config.tck_pin);
+}
+
+static inline void jtag_clk_low(void)
+{
+	bsp_gpio_clr(BSP_GPIO_PORTB, config.tck_pin);
+}
+
+static inline void jtag_tdi_high(void)
+{
+	bsp_gpio_set(BSP_GPIO_PORTB, config.tdi_pin);
+}
+
+static inline void jtag_tdi_low(void)
+{
+	bsp_gpio_clr(BSP_GPIO_PORTB, config.tdi_pin);
+}
+
+static inline void jtag_clock(void)
+{
+	jtag_clk_high();
+	wait_delay(10);
+	jtag_clk_low();
+}
+
+static void jtag_send_bit(uint8_t tdi)
+{
+	if (tdi & TMS) {
+		jtag_tms_high();
+	} else {
+		jtag_tms_low();
+	}
+	if (tdi) {
+		jtag_tdi_high();
+	}else{
+		jtag_tdi_low();
+	}
+	jtag_clock();
+}
+
+static uint8_t jtag_read_bit(void)
+{
+	return bsp_gpio_pin_read(BSP_GPIO_PORTB, config.tdo_pin);
+}
+
+static uint8_t jtag_read_bit_clock(void)
+{
+	uint8_t bit;
+	jtag_clk_high();
+	bit = bsp_gpio_pin_read(BSP_GPIO_PORTB, config.tdo_pin);
+	jtag_clk_low();
+	return bit;
+}
+
+static inline void jtag_reset_state(void)
+{
+	int i=5;
+	while(i>0){
+		jtag_send_bit(0 | TMS);
+		i--;
+	}
+	jtag_tms_low();
+	config.state = JTAG_STATE_RESET;
+}
+
+static void clkh(t_hydra_console *con)
+{
+	jtag_clk_high();
+	cprintf(con, "CLK HIGH\r\n");
+}
+
+static void clkl(t_hydra_console *con)
+{
+	jtag_clk_low();
+	cprintf(con, "CLK LOW\r\n");
+}
+
+static void clk(t_hydra_console *con)
+{
+	jtag_clock();
+	cprintf(con, "CLOCK PULSE\r\n");
+}
+
+static void dath(t_hydra_console *con)
+{
+	jtag_tdi_high();
+	cprintf(con, "TDI HIGH\r\n");
+}
+
+static void datl(t_hydra_console *con)
+{
+	jtag_tdi_low();
+	cprintf(con, "TDI LOW\r\n");
+}
+
+static void dats(t_hydra_console *con)
+{
+	uint8_t rx_data = jtag_read_bit_clock();
+	cprintf(con, hydrabus_mode_str_read_one_u8, rx_data);
+}
+
+static void start(t_hydra_console *con)
+{
+	jtag_tms_high();
+	cprintf(con, "TMS HIGH\r\n");
+}
+
+static void stop(t_hydra_console *con)
+{
+	jtag_tms_low();
+	cprintf(con, "TMS LOW\r\n");
+}
+
+static void bitr(t_hydra_console *con)
+{
+	uint8_t rx_data = jtag_read_bit();
+	cprintf(con, hydrabus_mode_str_read_one_u8, rx_data);
+}
+
+static void jtag_write_u8(uint8_t tx_data)
+{
+    uint8_t i;
+    for (i=0; i<8; i++) {
+        jtag_send_bit((tx_data>>i) & 1);
+    }
+}
+
+static uint8_t jtag_read_u8(void)
+{
+	uint8_t value;
+	uint8_t i;
+
+	value = 0;
+	for(i=0; i<8; i++) {
+		value |= (jtag_read_bit_clock() << i);
+	}
+	return value;
+}
+
+static uint32_t jtag_read_u32(void)
+{
+	uint32_t value;
+	uint8_t i;
+
+	value = 0;
+	for(i=0; i<32; i++) {
+		value |= (jtag_read_bit_clock() << i);
+	}
+	return value;
+}
+
+static uint8_t jtag_scan_bypass(void)
+{
+	uint16_t i;
+	uint8_t num_devices = 0;
+
+	//Reset state
+	jtag_reset_state();
+
+	//Shift-IR
+	jtag_send_bit(0);
+	jtag_send_bit(0 | TMS);
+	jtag_send_bit(0 | TMS);
+	jtag_send_bit(0);
+	jtag_send_bit(0);
+
+	/* Fill IR with 1 (BYPASS) */
+	for(i = 0; i < 999; i++) {
+		jtag_send_bit(1);
+	}
+	jtag_send_bit(1 | TMS);
+
+	//Switch to Shift-DR
+	jtag_send_bit(0 | TMS);
+	jtag_send_bit(0 | TMS);
+	jtag_send_bit(0);
+	jtag_send_bit(0);
+
+	/* Send 0 to fill DR */
+	for(i = 0; i < 1000; i++) {
+		jtag_send_bit(0);
+	}
+
+	jtag_tdi_high();
+	while( !jtag_read_bit_clock() ) {
+		num_devices++;
+	}
+	jtag_tdi_low();
+
+	return num_devices;
+}
+
+static bool jtag_scan_idcode(t_hydra_console *con)
+{
+	uint32_t idcode;
+	bool retval = false;
+
+	jtag_reset_state();
+
+	/* Go into Shift-DR state */
+	jtag_clock();
+	jtag_tms_high();
+	jtag_clock();
+	jtag_tms_low();
+	jtag_clock();
+	jtag_clock();
+
+	idcode = jtag_read_u32();
+	/* IDCODE bit0 must be 1 */
+	while(idcode != 0xffffffff && idcode & 0x1) {
+		cprintf(con, "Device found. IDCODE : %08X\r\n", idcode);
+		idcode = jtag_read_u32();
+		retval = true;
+	}
+	return retval;
+}
+
+static void jtag_brute_pins_bypass(t_hydra_console *con, uint8_t num_pins)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	uint8_t tck, tms, tdi, tdo, i;
+
+	for (tms = 0; tms < num_pins; tms++) {
+		for (tck = 0; tck < num_pins; tck++) {
+			for (tdi = 0; tdi < num_pins; tdi++) {
+				for (tdo = 0; tdo < num_pins; tdo++) {
+					if (tms == tck) continue;
+					if (tms == tdo) continue;
+					if (tms == tdi) continue;
+					if (tck == tdi) continue;
+					if (tck == tdo) continue;
+					if (tdi == tdo) continue;
+                    for(i = 0; i < num_pins; i++){
+                        bsp_gpio_init(BSP_GPIO_PORTB, i,
+                                proto->dev_gpio_mode, proto->dev_gpio_pull);
+                        bsp_gpio_set(BSP_GPIO_PORTB, i);
+                    }
+					config.tms_pin = tms;
+					config.tck_pin = tck;
+					config.tdi_pin = tdi;
+					config.tdo_pin = tdo;
+					jtag_pin_init(con);
+					if  (jtag_scan_bypass()) {
+						cprintf(con, "TMS: PB%d TCK: PB%d TDI: PB%d TDO: PB%d\r\n",
+								tms, tck, tdi, tdo);
+					}
+				}
+			}
+		}
+	}
+
+	jtag_pin_init(con);
+}
+
+static void jtag_brute_pins_idcode(t_hydra_console *con, uint8_t num_pins)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	uint8_t tck, tms, tdo;
+	uint8_t i;
+
+	for (tms = 0; tms < num_pins; tms++) {
+		for (tck = 0; tck < num_pins; tck++) {
+			for (tdo = 0; tdo < num_pins; tdo++) {
+				if (tms == tck) continue;
+				if (tms == tdo) continue;
+				if (tck == tdo) continue;
+                for(i = 0; i < num_pins; i++){
+                    bsp_gpio_init(BSP_GPIO_PORTB, i,
+                            proto->dev_gpio_mode, proto->dev_gpio_pull);
+                    bsp_gpio_set(BSP_GPIO_PORTB, i);
+                }
+				config.tms_pin = tms;
+				config.tck_pin = tck;
+				config.tdo_pin = tdo;
+				bsp_gpio_init(BSP_GPIO_PORTB, config.tdo_pin,
+						MODE_CONFIG_DEV_GPIO_IN,
+						MODE_CONFIG_DEV_GPIO_NOPULL);
+				if  (jtag_scan_idcode(con)) {
+					cprintf(con, "TMS: PB%d TCK: PB%d TDO: PB%d\r\n\r\n",
+							tms, tck, tdo);
+				}
+			}
+		}
+	}
+}
+
+static uint8_t ocd_shift_u8(uint8_t tdi, uint8_t tms, uint8_t num_bits)
+{
+	uint8_t tdo = 0;
+	uint8_t i = 0;
+
+	for(i = 0; i < num_bits; i++){
+		if(tms & 1){
+			jtag_tms_high();
+		}else{
+			jtag_tms_low();
+		}
+		if(tdi & 1){
+			jtag_tdi_high();
+		}else{
+			jtag_tdi_low();
+		}
+		jtag_clk_low();
+		jtag_clk_high();
+		tdo |= (jtag_read_bit() << i);
+		tdi = tdi >> 1;
+		tms = tms >> 1;
+	}
+	return tdo;
+}
+
+static void openOCD(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	uint8_t ocd_command;
+	uint8_t ocd_parameters[2] = {0};
+
+	uint16_t num_sequences, i;
+	uint16_t offset, bits;
+
+	cprintf(con, "Interrupt by pressing user button.\r\n");
+	cprint(con, "\r\n", 2);
+
+	while (!USER_BUTTON) {
+		if(chnReadTimeout(con->sdu, &ocd_command, 1, 1)) {
+			switch(ocd_command){
+			case CMD_OCD_UNKNOWN:
+				if(chSequentialStreamRead(con->sdu, g_sbuf, 19) == 19){
+					cprintf(con, "BBIO1");
+				}
+				break;
+			case CMD_OCD_ENTER_OOCD:
+				cprintf(con, "OCD1");
+				break;
+			case CMD_OCD_READ_ADCS:
+				/* Not implemented */
+				break;
+			case CMD_OCD_PORT_MODE:
+				if(chSequentialStreamRead(con->sdu, ocd_parameters, 1) == 1){
+					switch(ocd_parameters[0]){
+						case OCD_MODE_HIZ:
+							proto->dev_gpio_mode = MODE_CONFIG_DEV_GPIO_IN;
+							break;
+						case OCD_MODE_JTAG:
+							proto->dev_gpio_mode =
+									MODE_CONFIG_DEV_GPIO_OUT_PUSHPULL;
+							break;
+						case OCD_MODE_JTAG_OD:
+							proto->dev_gpio_mode =
+									MODE_CONFIG_DEV_GPIO_OUT_OPENDRAIN;
+							break;
+					}
+					jtag_pin_init(con);
+				}
+				break;
+			case CMD_OCD_FEATURE:
+				if(chSequentialStreamRead(con->sdu, ocd_parameters, 2) == 2){
+					switch(ocd_parameters[0]){
+						case FEATURE_LED:
+							/* Not implemented */
+							break;
+						case FEATURE_VREG:
+							/* Not implemented */
+							break;
+						case FEATURE_TRST:
+							//TODO
+							break;
+						case FEATURE_SRST:
+							//TODO
+							break;
+						case FEATURE_PULLUP:
+							if(ocd_parameters[1]){
+								proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_PULLUP;
+							}else{
+								proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_NOPULL;
+							}
+							break;
+					}
+					jtag_pin_init(con);
+				}else{
+					cprint(con, "\x00", 1);
+				}
+				break;
+			case CMD_OCD_JTAG_SPEED:
+				//TODO
+				if(chSequentialStreamRead(con->sdu, ocd_parameters, 2) == 2){
+				}
+				break;
+			case CMD_OCD_UART_SPEED:
+				/* Not implemented */
+				if(chSequentialStreamRead(con->sdu, ocd_parameters, 1) == 1){
+					cprintf(con, "%c%c", CMD_OCD_UART_SPEED,
+							ocd_parameters[0]);
+				}else{
+					cprint(con, "\x00", 1);
+				}
+
+				break;
+			case CMD_OCD_TAP_SHIFT:
+				if(chSequentialStreamRead(con->sdu, ocd_parameters, 2) == 2){
+					num_sequences = ocd_parameters[0] << 8;
+					num_sequences |= ocd_parameters[1];
+					cprintf(con, "%c%c%c", CMD_OCD_TAP_SHIFT, ocd_parameters[0],
+							ocd_parameters[1]);
+
+					chSequentialStreamRead(con->sdu, g_sbuf,((num_sequences+7)/8)*2);
+					for(i = 0; i < num_sequences; i+=8){
+                        offset = i/8;
+                        if((num_sequences-8*offset) < 8){
+                            bits = num_sequences % 8;
+                        }else{
+                            bits=8;
+                        }
+						cprintf(con, "%c",
+								ocd_shift_u8(g_sbuf[2*offset],
+										g_sbuf[(2*offset)+1],
+										bits ));
+					}
+				}else{
+					cprint(con, "\x00", 1);
+				}
+				break;
+			default:
+				cprint(con, "\x00", 1);
+				break;
+			}
+		}
+	}
+}
+
+static int init(t_hydra_console *con, t_tokenline_parsed *p)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	int tokens_used;
+
+	/* Defaults */
+	init_proto_default(con);
+
+	/* Process cmdline arguments, skipping "jtag". */
+	tokens_used = 1 + exec(con, p, 1);
+
+	jtag_pin_init(con);
+	jtag_clk_low();
+	jtag_tms_low();
+	jtag_tdi_low();
+
+	show_params(con);
+
+	return tokens_used;
+}
+
+static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	int arg_int, t;
+
+	for (t = token_pos; p->tokens[t]; t++) {
+		switch (p->tokens[t]) {
+		case T_SHOW:
+			t += show(con, p);
+			break;
+		case T_PULL:
+			switch (p->tokens[++t]) {
+			case T_UP:
+				proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_PULLUP;
+				break;
+			case T_DOWN:
+				proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_PULLDOWN;
+				break;
+			case T_FLOATING:
+				proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_NOPULL;
+				break;
+			}
+			jtag_pin_init(con);
+			break;
+		case T_BRUTE:
+			/* Integer parameter. */
+			memcpy(&arg_int, p->buf + p->tokens[t+3], sizeof(int));
+			cprintf(con, "Bruteforce on %d pins.\r\n", arg_int);
+			if (arg_int < 1 || arg_int > 12) {
+				cprintf(con, "Cannot use more than 12 pins (PB0-11).\r\n");
+				return t;
+			}
+			switch(p->tokens[t+1]){
+			case T_BYPASS:
+				jtag_brute_pins_bypass(con, arg_int);
+				break;
+			case T_IDCODE:
+				jtag_brute_pins_idcode(con, arg_int);
+				break;
+			}
+			t+=3;
+			break;
+        case T_TCK:
+			/* Integer parameter. */
+			memcpy(&arg_int, p->buf + p->tokens[t+3], sizeof(int));
+			if (arg_int < 0 || arg_int > 12) {
+				cprintf(con, "Pin must be between 0 and 11 (PB0-11).\r\n");
+				return t;
+			}
+            config.tck_pin = arg_int;
+			t+=3;
+            break;
+        case T_TMS:
+			/* Integer parameter. */
+			memcpy(&arg_int, p->buf + p->tokens[t+3], sizeof(int));
+			if (arg_int < 0 || arg_int > 12) {
+				cprintf(con, "Pin must be between 0 and 11 (PB0-11).\r\n");
+				return t;
+			}
+            config.tms_pin = arg_int;
+			t+=3;
+            break;
+        case T_TDI:
+			/* Integer parameter. */
+			memcpy(&arg_int, p->buf + p->tokens[t+3], sizeof(int));
+			if (arg_int < 0 || arg_int > 12) {
+				cprintf(con, "Pin must be between 0 and 11 (PB0-11).\r\n");
+				return t;
+			}
+            config.tdi_pin = arg_int;
+			t+=3;
+            break;
+        case T_TDO:
+			/* Integer parameter. */
+			memcpy(&arg_int, p->buf + p->tokens[t+3], sizeof(int));
+			if (arg_int < 0 || arg_int > 12) {
+				cprintf(con, "Pin must be between 0 and 11 (PB0-11).\r\n");
+				return t;
+			}
+            config.tdo_pin = arg_int;
+			t+=3;
+            break;
+		case T_BYPASS:
+			cprintf(con, "Number of devices found : %d\r\n", jtag_scan_bypass());
+			break;
+		case T_IDCODE:
+			jtag_scan_idcode(con);
+			break;
+		case T_OOCD:
+			openOCD(con);
+			break;
+		default:
+			return t - token_pos;
+		}
+	}
+
+	return t - token_pos;
+}
+
+static uint32_t write(t_hydra_console *con, uint8_t *tx_data, uint8_t nb_data)
+{
+	int i;
+	uint32_t status;
+	mode_config_proto_t* proto = &con->mode->proto;
+	for (i = 0; i < nb_data; i++) {
+		jtag_write_u8(tx_data[i]);
+	}
+	if(status == BSP_OK) {
+		if(nb_data == 1) {
+			/* Write 1 data */
+			cprintf(con, hydrabus_mode_str_write_one_u8, tx_data[0]);
+		} else if(nb_data > 1) {
+			/* Write n data */
+			cprintf(con, hydrabus_mode_str_mul_write);
+			for(i = 0; i < nb_data; i++) {
+				cprintf(con, hydrabus_mode_str_mul_value_u8,
+						tx_data[i]);
+			}
+			cprintf(con, hydrabus_mode_str_mul_br);
+		}
+	}
+	return status;
+}
+
+static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+{
+	int i;
+	uint32_t status;
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	for(i = 0; i < nb_data; i++){
+		rx_data[i] = jtag_read_u8();
+	}
+	if(status == BSP_OK) {
+		if(nb_data == 1) {
+			/* Read 1 data */
+			cprintf(con, hydrabus_mode_str_read_one_u8, rx_data[0]);
+		} else if(nb_data > 1) {
+			/* Read n data */
+			cprintf(con, hydrabus_mode_str_mul_read);
+			for(i = 0; i < nb_data; i++) {
+				cprintf(con, hydrabus_mode_str_mul_value_u8,
+						rx_data[i]);
+			}
+			cprintf(con, hydrabus_mode_str_mul_br);
+		}
+	}
+	return status;
+}
+
+static void cleanup(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+}
+
+static int show(t_hydra_console *con, t_tokenline_parsed *p)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	int tokens_used;
+
+	tokens_used = 0;
+	if (p->tokens[1] == T_PINS) {
+		tokens_used++;
+        cprintf(con, "TMS: PB%d\r\nTCK: PB%d\r\nTDI: PB%d\r\nTDO: PB%d\r\n",
+                config.tms_pin, config.tck_pin, config.tdi_pin, config.tdo_pin);
+	} else {
+		show_params(con);
+	}
+
+	return tokens_used;
+}
+
+static const char *get_prompt(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	return str_prompt_jtag[proto->dev_num];
+}
+
+const mode_exec_t mode_jtag_exec = {
+	.init = &init,
+	.exec = &exec,
+	.write = &write,
+	.read = &read,
+	.cleanup = &cleanup,
+	.get_prompt = &get_prompt,
+	.clkl = &clkl,
+	.clkh = &clkh,
+	.clk = &clk,
+	.dath = &dath,
+	.datl = &datl,
+	.dats = &dats,
+	.bitr = &bitr,
+	.start = &start,
+	.stop = &stop,
+};
+

--- a/hydrabus/hydrabus_mode_jtag.h
+++ b/hydrabus/hydrabus_mode_jtag.h
@@ -1,0 +1,72 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2012-2014 Benjamin VERNOUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hydrabus_mode.h"
+
+#define TMS     0b10
+
+#define CMD_OCD_UNKNOWN       0x00
+#define CMD_OCD_PORT_MODE     0x01
+#define CMD_OCD_FEATURE       0x02
+#define CMD_OCD_READ_ADCS     0x03
+//#define CMD_OCD_TAP_SHIFT     0x04 // old protocol
+#define CMD_OCD_TAP_SHIFT     0x05
+#define CMD_OCD_ENTER_OOCD    0x06 // this is the same as in binIO
+#define CMD_OCD_UART_SPEED    0x07
+#define CMD_OCD_JTAG_SPEED    0x08
+
+typedef enum {
+JTAG_STATE_RESET,
+JTAG_STATE_IDLE,
+JTAG_STATE_DR_SCAN,
+JTAG_STATE_DR_CAPTURE,
+JTAG_STATE_DR_SHIFT,
+JTAG_STATE_DR_EXIT_1,
+JTAG_STATE_DR_PAUSE,
+JTAG_STATE_DR_EXIT_2,
+JTAG_STATE_DR_UPDATE,
+JTAG_STATE_IR_SCAN,
+JTAG_STATE_IR_CAPTURE,
+JTAG_STATE_IR_SHIFT,
+JTAG_STATE_IR_EXIT_1,
+JTAG_STATE_IR_PAUSE,
+JTAG_STATE_IR_EXIT_2,
+JTAG_STATE_IR_UPDATE
+} jtag_state;
+
+typedef struct {
+    uint8_t tdi_pin;
+    uint8_t tdo_pin;
+    uint8_t tms_pin;
+    uint8_t tck_pin;
+    jtag_state state;
+}jtag_config;
+
+enum {
+    OCD_MODE_HIZ=0,
+    OCD_MODE_JTAG=1,
+    OCD_MODE_JTAG_OD=2, // open-drain outputs
+};
+
+enum {
+    FEATURE_LED=0x01,
+    FEATURE_VREG=0x02,
+    FEATURE_TRST=0x04,
+    FEATURE_SRST=0x08,
+    FEATURE_PULLUP=0x10
+};


### PR DESCRIPTION
Software JTAG for Hydrabus.
=======================

This is a first implementation of the JTAG protocol for the HydraBus

Features : 
---------------
 - Classic JTAG (TDI/TDO/TMS/TCK)
 - Can be used with command line
 - BusPirate-compatible OpenOCD binary mode ( _openocd_ command)
 -  Can scan a JTAG bus with IDCODE and BYPASS methods ( _idcode_ and _bypass_ commands)
 - Can try to find  JTAG bus on all GPIOB pins (like JTAGulator) ( _brute_ command)

TODO:
----------

 - Enhance port speed
 - Enhance binary mode
 - Add support for TRST
 - Add support for MSB/LSB when reading