### PR TITLE
STM32 hardware RNG support

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -166,6 +166,7 @@ int cmd_dac(t_hydra_console *con, t_tokenline_parsed *p);
 int cmd_pwm(t_hydra_console *con, t_tokenline_parsed *p);
 int cmd_gpio(t_hydra_console *con, t_tokenline_parsed *p);
 int cmd_sump(t_hydra_console *con, t_tokenline_parsed *p);
+int cmd_rng(t_hydra_console *con, t_tokenline_parsed *p);
 
 void token_dump(t_hydra_console *con, t_tokenline_parsed *p);
 void cprint(t_hydra_console *con, const char *data, const uint32_t size);

--- a/common/exec.c
+++ b/common/exec.c
@@ -241,6 +241,7 @@ static struct cmd_map {
 	{ T_GPIO, cmd_gpio },
 	{ T_SUMP, cmd_sump },
 	{ T_JTAG, cmd_mode_init },
+	{ T_RNG, cmd_rng },
 	{ 0, NULL }
 };
 

--- a/drv/stm32cube/bsp_rng.c
+++ b/drv/stm32cube/bsp_rng.c
@@ -1,0 +1,73 @@
+/*
+HydraBus/HydraNFC - Copyright (C) 2014 Benjamin VERNOUX
+HydraBus/HydraNFC - Copyright (C) 2015 Nicolas OBERLI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "bsp_rng.h"
+#include "stm32f405xx.h"
+
+static RNG_HandleTypeDef *hrng;
+
+/** \brief Init RNG device.
+ *
+ * \return bsp_status_t: status of the init.
+ *
+ */
+bsp_status_t bsp_rng_init()
+{
+        hrng->Instance = RNG;
+
+        /* Configure the RNG peripheral */
+        __RNG_CLK_ENABLE();
+
+        __HAL_RNG_ENABLE(hrng);
+
+        /*
+        if(HAL_RNG_Init(hrng) != HAL_OK) {
+        	return BSP_ERROR;
+        }
+        */
+
+        return BSP_OK;
+}
+
+/** \brief De-initialize the RNG device.
+ *
+ * \return bsp_status_t: Status of the deinit.
+ *
+ */
+bsp_status_t bsp_rng_deinit()
+{
+        __RNG_CLK_DISABLE();
+
+        __HAL_RNG_DISABLE(hrng);
+
+        return BSP_OK;
+}
+
+/** \brief
+ *
+ * \param dev_num bsp_dev_rng_t: RNG dev num.
+ * \param rx_data uint16_t*: The received byte.
+ * \param nb_data uint8_t: Number of byte to received.
+ * \return bsp_status_t: Status of the transfer.
+ *
+ */
+uint32_t bsp_rng_read()
+{
+        while (!(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY)) || USER_BUTTON) {
+        }
+
+        return hrng->Instance->DR;
+}
+

--- a/drv/stm32cube/bsp_rng.h
+++ b/drv/stm32cube/bsp_rng.h
@@ -1,0 +1,27 @@
+/*
+HydraBus/HydraNFC - Copyright (C) 2014 Benjamin VERNOUX
+HydraBus/HydraNFC - Copyright (C) 2015 Nicolas OBERLI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef _BSP_RNG_H_
+#define _BSP_RNG_H_
+
+#include "bsp.h"
+#include "stm32f4xx_hal.h"
+
+bsp_status_t bsp_rng_init(void);
+bsp_status_t bsp_rng_deinit(void);
+
+uint32_t bsp_rng_read(void);
+
+#endif /* _BSP_RNG_H_ */

--- a/drv/stm32cube/stm32cube.mk
+++ b/drv/stm32cube/stm32cube.mk
@@ -15,7 +15,8 @@ STM32CUBESRC = ./drv/stm32cube/stm32f4xx_hal_msp.c \
               ./drv/stm32cube/bsp_gpio.c \
               ./drv/stm32cube/bsp_i2c.c \
               ./drv/stm32cube/bsp_spi.c \
-              ./drv/stm32cube/bsp_uart.c
+              ./drv/stm32cube/bsp_uart.c \
+              ./drv/stm32cube/bsp_rng.c
 
 # Required include directories
 STM32CUBEINC = ./drv/stm32cube \

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -123,6 +123,7 @@ t_token_dict tl_dict[] = {
 	{ T_BYPASS, "bypass" },
 	{ T_IDCODE, "idcode" },
 	{ T_OOCD, "openocd" },
+	{ T_RNG, "random" },
 
 	{ T_LEFT_SQ, "[" },
 	{ T_RIGHT_SQ, "]" },
@@ -979,6 +980,10 @@ t_token tl_tokens[] = {
 		T_JTAG,
 		.subtokens = tokens_jtag,
 		.help = "JTAG mode"
+	},
+	{
+		T_RNG,
+		.help = "Random number"
 	},
 	{
 		T_DEBUG,

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -116,6 +116,7 @@ enum {
 	T_BYPASS,
 	T_IDCODE,
 	T_OOCD,
+	T_RNG,
 
 	/* BP-compatible commands */
 	T_LEFT_SQ,

--- a/hydrabus/hydrabus.mk
+++ b/hydrabus/hydrabus.mk
@@ -10,6 +10,8 @@ HYDRABUSSRC = hydrabus/hydrabus.c \
             hydrabus/hydrabus_mode_uart.c \
             hydrabus/hydrabus_mode_i2c.c \
             hydrabus/hydrabus_sump.c \
-            hydrabus/hydrabus_mode_jtag.c
+            hydrabus/hydrabus_mode_jtag.c \
+            hydrabus/hydrabus_rng.c
+
 # Required include directories
 HYDRABUSINC = ./hydrabus

--- a/hydrabus/hydrabus_rng.c
+++ b/hydrabus/hydrabus_rng.c
@@ -1,0 +1,37 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2012-2014 Benjamin VERNOUX
+ * Copyright (C) 2015 Nioclas OBERLI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common.h"
+#include "tokenline.h"
+#include "hydrabus.h"
+#include "bsp_rng.h"
+#include "stm32f4xx_hal.h"
+
+#include <string.h>
+
+
+int cmd_rng(t_hydra_console *con, t_tokenline_parsed *p)
+{
+	bsp_rng_init();
+
+	cprintf(con, "%02X\r\n", bsp_rng_read());
+
+	bsp_rng_deinit();
+}
+


### PR DESCRIPTION
Support for STM32 hardware RNG

- new  *random* command returns a 32bit random number in hex