### PR TITLE
Addrd new token ~ to write random byte

### DIFF
--- a/drv/stm32cube/bsp_rng.c
+++ b/drv/stm32cube/bsp_rng.c
@@ -48,23 +48,24 @@ bsp_status_t bsp_rng_init()
  */
 bsp_status_t bsp_rng_deinit()
 {
-        __RNG_CLK_DISABLE();
+        hrng->Instance = RNG;
 
         __HAL_RNG_DISABLE(hrng);
+
+        __RNG_CLK_DISABLE();
 
         return BSP_OK;
 }
 
-/** \brief
+/** \brief Returns a random number from the RNG
  *
- * \param dev_num bsp_dev_rng_t: RNG dev num.
- * \param rx_data uint16_t*: The received byte.
- * \param nb_data uint8_t: Number of byte to received.
- * \return bsp_status_t: Status of the transfer.
+ * \return uint32_t: Random number
  *
  */
 uint32_t bsp_rng_read()
 {
+        hrng->Instance = RNG;
+
         while (!(__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY)) || USER_BUTTON) {
         }
 

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -138,6 +138,7 @@ t_token_dict tl_dict[] = {
 	{ T_DOT, "." },
 	{ T_AMPERSAND, "&" },
 	{ T_PERCENT, "%" },
+	{ T_TILDE, "~" },
 	{ }
 };
 
@@ -326,6 +327,11 @@ t_token tokens_mode_uart[] = {
 		.help = "Delay 1 msec (repeat with :<num>)"
 	},
 	{
+		T_TILDE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write a random byte (repeat with :<num>)"
+	},
+	{
 		T_BRIDGE,
 		.help = "UART bridge mode"
 	},
@@ -407,6 +413,11 @@ t_token tokens_mode_i2c[] = {
 		T_PERCENT,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Delay 1 msec (repeat with :<num>)"
+	},
+	{
+		T_TILDE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write a random byte (repeat with :<num>)"
 	},
 	{
 		T_EXIT,
@@ -495,6 +506,11 @@ t_token tokens_mode_spi[] = {
 		T_PERCENT,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Delay 1 msec (repeat with :<num>)"
+	},
+	{
+		T_TILDE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write a random byte (repeat with :<num>)"
 	},
 	{
 		T_EXIT,
@@ -623,6 +639,11 @@ t_token tokens_mode_jtag[] = {
 		T_PERCENT,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Delay 1 msec (repeat with :<num>)"
+	},
+	{
+		T_TILDE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write a random byte (repeat with :<num>)"
 	},
 	{
 		T_EXIT,

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -132,5 +132,6 @@ enum {
 	T_DOT,
 	T_AMPERSAND,
 	T_PERCENT,
+	T_TILDE,
 };
 

--- a/hydrabus/hydrabus_rng.c
+++ b/hydrabus/hydrabus_rng.c
@@ -21,17 +21,20 @@
 #include "tokenline.h"
 #include "hydrabus.h"
 #include "bsp_rng.h"
-#include "stm32f4xx_hal.h"
 
 #include <string.h>
 
 
 int cmd_rng(t_hydra_console *con, t_tokenline_parsed *p)
 {
+	(void)p;
+
 	bsp_rng_init();
 
 	cprintf(con, "%02X\r\n", bsp_rng_read());
 
 	bsp_rng_deinit();
+
+	return TRUE;
 }
 


### PR DESCRIPTION
Command line now supports the *~* command to write a random byte.

Example : 
```
> uart 
Device: UART1
Speed: 9600 bps
Parity: none
Stop bits: 1
uart1> ~ ~ ~ ~ ~
WRITE: 0x3F 0x40 0x4A 0x59 0xC0 
uart1> ~:5
WRITE: 0xEC 0xEC 0xEC 0xEC 0xEC 
uart1> 
```