### PR TITLE
Added freeform string input on command line

### DIFF
--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -371,6 +371,10 @@ t_token tokens_mode_uart[] = {
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"
 	},
+	{
+		T_ARG_STRING,
+		.help = "Write string"
+	},
 	/* BP commands */
 	{
 		T_AMPERSAND,
@@ -453,6 +457,10 @@ t_token tokens_mode_can[] = {
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write packets (repeat with :<num>)"
 	},
+	{
+		T_ARG_STRING,
+		.help = "Write string"
+	},
 	/* BP commands */
 	{
 		T_TILDE,
@@ -518,6 +526,10 @@ t_token tokens_mode_i2c[] = {
 		T_ARG_UINT,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_ARG_STRING,
+		.help = "Write string"
 	},
 	/* BP commands */
 	{
@@ -605,6 +617,10 @@ t_token tokens_mode_spi[] = {
 		.help = "Write byte (repeat with :<num>)"
 	},
 	{
+		T_ARG_STRING,
+		.help = "Write string"
+	},
+	{
 		T_CS_ON,
 		.help = "Alias for \"chip-select on\""
 	},
@@ -688,6 +704,10 @@ t_token tokens_mode_jtag[] = {
 		T_ARG_UINT,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_ARG_STRING,
+		.help = "Write string"
 	},
 	{
 		T_TCK,
@@ -830,6 +850,10 @@ t_token tokens_mode_twowire[] = {
 		T_ARG_UINT,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_ARG_STRING,
+		.help = "Write string"
 	},
 	/* BP commands */
 	{


### PR DESCRIPTION
This patch adds the possibility to write strings in the command line that will be converted to their ASCII counterpart before being sent on each protocol : 

```
> uart 
Device: UART1
Speed: 9600 bps
Parity: none
Stop bits: 1
uart1> "Hello world"
WRITE: 0x48 0x65 0x6C 0x6C 0x6F 0x20 0x77 0x6F 0x72 0x6C 0x64 
uart1> 0x01 "A" "B" 0x2:2
WRITE: 0x01
WRITE: 0x41
WRITE: 0x42
WRITE: 0x02 0x02 
uart1> test
WRITE: 0x74 0x65 0x73 0x74 
>
```