### PR TITLE
Scripting support

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -5,7 +5,7 @@ COMMONSRC = common/common.c \
             common/usb1cfg.c \
             common/usb2cfg.c \
             common/fault_handler.c \
-			common/script.c
+            common/script.c
 
 COMMONSRC_ASM = common/fault_handler_asm.s
 

--- a/common/common.mk
+++ b/common/common.mk
@@ -4,7 +4,8 @@ COMMONSRC = common/common.c \
             common/microsd.c \
             common/usb1cfg.c \
             common/usb2cfg.c \
-            common/fault_handler.c
+            common/fault_handler.c \
+			common/script.c
 
 COMMONSRC_ASM = common/fault_handler_asm.s
 

--- a/common/ffconf.h
+++ b/common/ffconf.h
@@ -36,7 +36,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define	_USE_STRFUNC	0	/* 0:Disable or 1-2:Enable */
+#define	_USE_STRFUNC	1	/* 0:Disable or 1-2:Enable */
 /* To enable string functions, set _USE_STRFUNC to 1 or 2. */
 
 

--- a/common/microsd.c
+++ b/common/microsd.c
@@ -30,8 +30,8 @@
 #include "microsd.h"
 #include "common.h"
 
-#define SDC_BURST_SIZE  4 /* how many sectors reads at once */
-#define IN_OUT_BUF_SIZE (MMCSD_BLOCK_SIZE * SDC_BURST_SIZE)
+#include "script.h"
+
 static uint8_t outbuf[IN_OUT_BUF_SIZE+8];
 static uint8_t inbuf[IN_OUT_BUF_SIZE+8];
 
@@ -948,6 +948,22 @@ int cmd_sd_mkdir(t_hydra_console *con, t_tokenline_parsed *p)
 	return TRUE;
 }
 
+int cmd_sd_script(t_hydra_console *con, t_tokenline_parsed *p)
+{
+#define MAX_FILE_SIZE (524288)
+	int str_offset;
+
+	if (p->tokens[2] != T_ARG_STRING || p->tokens[4] != 0)
+		return FALSE;
+
+	memcpy(&str_offset, &p->tokens[3], sizeof(int));
+	snprintf(filename, FILENAME_SIZE, "0:%s", p->buf + str_offset);
+
+	execute_script(con, filename);
+
+	return TRUE;
+}
+
 int cmd_sd(t_hydra_console *con, t_tokenline_parsed *p)
 {
 	int ret;
@@ -990,6 +1006,9 @@ int cmd_sd(t_hydra_console *con, t_tokenline_parsed *p)
 		break;
 	case T_MKDIR:
 		ret = cmd_sd_mkdir(con, p);
+		break;
+	case T_SCRIPT:
+		ret = cmd_sd_script(con, p);
 		break;
 	default:
 		return FALSE;

--- a/common/microsd.c
+++ b/common/microsd.c
@@ -61,6 +61,23 @@ bool is_fs_ready(void)
 	return fs_ready;
 }
 
+bool is_file_present(char * filename)
+{
+	FRESULT err;
+	if (!fs_ready) {
+		err = mount();
+		if(err) {
+			return FALSE;
+		}
+	}
+
+	err = f_stat(filename, NULL);
+	if (err == FR_OK) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
 /**
  * @brief   Parody of UNIX badblocks program.
  *

--- a/common/microsd.h
+++ b/common/microsd.h
@@ -29,6 +29,7 @@ typedef struct {
 } filename_t;
 
 bool is_fs_ready(void);
+bool is_file_present(char * filename);
 
 int write_file(uint8_t* buffer, uint32_t size);
 void write_file_get_last_filename(filename_t* out_filename);

--- a/common/script.c
+++ b/common/script.c
@@ -1,0 +1,55 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2016 Nicolas OBERLI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ff.h"
+#include "microsd.h"
+
+static uint8_t inbuf[IN_OUT_BUF_SIZE+8];
+
+int execute_script(t_hydra_console *con, char *filename)
+{
+	FRESULT err;
+	FIL fp;
+	int i;
+	if (!is_fs_ready()) {
+		err = mount();
+		if(err) {
+			cprintf(con, "Mount failed: error %d.\r\n", err);
+			return FALSE;
+		}
+	}
+
+	err = f_open(&fp, (TCHAR *)filename, FA_READ | FA_OPEN_EXISTING);
+	if (err != FR_OK) {
+		cprintf(con, "Failed to open file %s: error %d.\r\n", filename, err);
+		return FALSE;
+	}
+
+	/* Clear any input in tokenline buffer */
+	tl_input(con->tl, 0x03);
+
+	while(!f_eof(&fp)) {
+		f_gets((TCHAR *)inbuf, IN_OUT_BUF_SIZE, &fp);
+		i=0;
+		while(inbuf[i] != '\0') {
+			tl_input(con->tl, inbuf[i]);
+			i++;
+		}
+	}
+	return TRUE;
+}

--- a/common/script.c
+++ b/common/script.c
@@ -46,6 +46,9 @@ int execute_script(t_hydra_console *con, char *filename)
 	while(!f_eof(&fp)) {
 		f_gets((TCHAR *)inbuf, IN_OUT_BUF_SIZE, &fp);
 		i=0;
+		if(inbuf[0] == '#') {
+			continue;
+		}
 		while(inbuf[i] != '\0') {
 			tl_input(con->tl, inbuf[i]);
 			i++;

--- a/common/script.h
+++ b/common/script.h
@@ -1,7 +1,7 @@
 /*
  * HydraBus/HydraNFC
  *
- * Copyright (C) 2014-2015 Benjamin VERNOUX
+ * Copyright (C) 2016 Nicolas OBERLI
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,4 @@
  * limitations under the License.
  */
 
-#ifndef _MICROSD_H_
-#define _MICROSD_H_
-
-#define SDC_BURST_SIZE  4 /* how many sectors reads at once */
-#define IN_OUT_BUF_SIZE (MMCSD_BLOCK_SIZE * SDC_BURST_SIZE)
-
-#include "common.h"
-
-typedef struct {
-	char filename[255];
-} filename_t;
-
-bool is_fs_ready(void);
-
-int write_file(uint8_t* buffer, uint32_t size);
-void write_file_get_last_filename(filename_t* out_filename);
-
-int mount(void);
-int umount(void);
-
-#endif /* _MICROSD_H_ */
+int execute_script(t_hydra_console *con, char *filename);

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -135,6 +135,7 @@ t_token_dict tl_dict[] = {
 	{ T_LOW, "low" },
 	{ T_HIGH, "high" },
 	{ T_THREEWIRE, "3-wire" },
+	{ T_SCRIPT, "script" },
 
 	{ T_LEFT_SQ, "[" },
 	{ T_RIGHT_SQ, "]" },
@@ -1225,6 +1226,11 @@ t_token tokens_sd[] = {
 		T_MKDIR,
 		.arg_type = T_ARG_STRING,
 		.help = "Create new directory"
+	},
+	{
+		T_SCRIPT,
+		.arg_type = T_ARG_STRING,
+		.help = "Execute script from file"
 	},
 	{ }
 };

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -128,6 +128,7 @@ enum {
 	T_LOW,
 	T_HIGH,
 	T_THREEWIRE,
+	T_SCRIPT,
 
 	/* BP-compatible commands */
 	T_LEFT_SQ,

--- a/main.c
+++ b/main.c
@@ -38,6 +38,10 @@
 
 #include "bsp.h"
 
+#include "script.h"
+
+#define INIT_SCRIPT_NAME "initscript"
+
 volatile int nb_console = 0;
 
 /* USB1: Virtual serial port over USB. */
@@ -71,6 +75,10 @@ THD_FUNCTION(console, arg)
 	tl_init(con->tl, tl_tokens, tl_dict, print, con);
 	tl_set_prompt(con->tl, PROMPT);
 	tl_set_callback(con->tl, execute);
+
+	if(is_file_present(INIT_SCRIPT_NAME)) {
+		execute_script(con,INIT_SCRIPT_NAME);
+	}
 
 	while (1) {
 		input = get_char(con);


### PR DESCRIPTION
This PR adds a new *sd script* subcommand to execute commands stored in a text file on an SD card.
Rules are simple : 
 - One command per line
 - Any line beginning with a **#** will be ignored

It is also possible to create a file called *initscript* at the root of the sdcard that will be automatically executed everytime the console is initialized.