### PR TITLE
Hexdump in console

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -78,6 +78,37 @@ void cprint(t_hydra_console *con, const char *data, const uint32_t size)
 	stream_write(con, data, size);
 }
 
+
+void print_hex(t_hydra_console *con, uint8_t* data, uint8_t size)
+{
+	uint8_t ascii[17];
+	uint8_t i, j;
+	ascii[16] = '\0';
+	for (i = 0; i < size; ++i) {
+		cprintf(con, "%02X ", data[i]);
+		if (data[i] >= 0x20 && data[i] <= 0x7f) {
+			ascii[i % 16] = data[i];
+		} else {
+			ascii[i % 16] = '.';
+		}
+		if ((i+1) % 8 == 0 || i+1 == size) {
+			cprintf(con, " ");
+			if ((i+1) % 16 == 0) {
+				cprintf(con, "|  %s \r\n", ascii);
+			} else if (i+1 == size) {
+				ascii[(i+1) % 16] = '\0';
+				if ((i+1) % 16 <= 8) {
+					cprintf(con, " ");
+				}
+				for (j = (i+1) % 16; j < 16; ++j) {
+					cprintf(con, "   ");
+				}
+				cprintf(con, "|  %s \r\n", ascii);
+			}
+		}
+	}
+}
+
 void cprintf(t_hydra_console *con, const char *fmt, ...)
 {
 	va_list va_args;

--- a/common/common.h
+++ b/common/common.h
@@ -174,5 +174,6 @@ void cprint(t_hydra_console *con, const char *data, const uint32_t size);
 void cprintf(t_hydra_console *con, const char *fmt, ...);
 void print_dbg(const char *data, const uint32_t size);
 void printf_dbg(const char *fmt, ...);
+void print_hex(t_hydra_console *con, uint8_t* data, uint8_t size);
 
 #endif /* _COMMON_H_ */

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -638,6 +638,11 @@ t_token tokens_mode_spi[] = {
 		.help = "Read byte (repeat with :<num>)"
 	},
 	{
+		T_HD,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>) and print hexdump"
+	},
+	{
 		T_WRITE,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -549,6 +549,11 @@ t_token tokens_mode_i2c[] = {
 		.help = "Read byte (repeat with :<num>)"
 	},
 	{
+		T_HD,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>) and print hexdump"
+	},
+	{
 		T_WRITE,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -393,6 +393,11 @@ t_token tokens_mode_uart[] = {
 		.help = "Read byte (repeat with :<num>)"
 	},
 	{
+		T_HD,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>) and print hexdump"
+	},
+	{
 		T_WRITE,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -878,6 +878,11 @@ t_token tokens_mode_twowire[] = {
 		.help = "Read byte (repeat with :<num>)"
 	},
 	{
+		T_HD,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>) and print hexdump"
+	},
+	{
 		T_WRITE,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write byte (repeat with :<num>)"
@@ -977,6 +982,11 @@ t_token tokens_mode_threewire[] = {
 		T_READ,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Read byte (repeat with :<num>)"
+	},
+	{
+		T_HD,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>) and print hexdump"
 	},
 	{
 		T_WRITE,

--- a/hydrabus/hydrabus_mode_twowire.c
+++ b/hydrabus/hydrabus_mode_twowire.c
@@ -27,6 +27,7 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
 
 static twowire_config config;
 static TIM_HandleTypeDef htim;
@@ -279,7 +280,7 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
 	float arg_float;
-	int t;
+	int arg_int, t;
 
 	for (t = token_pos; p->tokens[t]; t++) {
 		switch (p->tokens[t]) {
@@ -315,6 +316,16 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 				proto->dev_speed = (int)arg_float;
 				twowire_tim_set_prescaler(con);
 			}
+			break;
+		case T_HD:
+			/* Integer parameter. */
+			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
+				t += 2;
+				memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+			} else {
+				arg_int = 1;
+			}
+			dump(con, proto->buffer_rx, arg_int);
 			break;
 		default:
 			return t - token_pos;
@@ -364,6 +375,17 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 		}
 		cprintf(con, hydrabus_mode_str_mul_br);
 	}
+	return BSP_OK;
+}
+
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+{
+	int i;
+
+	for(i = 0; i < nb_data; i++) {
+		rx_data[i] = twowire_read_u8(con);
+	}
+	print_hex(con, rx_data, nb_data);
 	return BSP_OK;
 }
 

--- a/hydrabus/hydrabus_mode_uart.c
+++ b/hydrabus/hydrabus_mode_uart.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "common.h"
 #include "hydrabus_mode_uart.h"
 #include "bsp_uart.h"
 #include <string.h>
@@ -24,6 +25,7 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
 
 static const char* str_pins_uart[] = {
 	"TX: PA9\r\nRX: PA10\r\n",
@@ -222,6 +224,16 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 		case T_BRIDGE:
 			bridge(con);
 			break;
+		case T_HD:
+			/* Integer parameter. */
+			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
+				t += 2;
+				memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+			} else {
+				arg_int = 1;
+			}
+			dump(con, proto->buffer_rx, arg_int);
+			break;
 		default:
 			return t - token_pos;
 		}
@@ -272,6 +284,18 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 			}
 			cprintf(con, hydrabus_mode_str_mul_br);
 		}
+	}
+	return status;
+}
+
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+{
+	uint32_t status;
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data);
+	if(status == BSP_OK) {
+		print_hex(con, rx_data, nb_data);
 	}
 	return status;
 }


### PR DESCRIPTION
This PR adds the ´hd´ (HexDump) command in the following modes : 
- spi
- i2c
- uart
- 2- and 3-wire

For instance, this displays the first 32 bytes of an i2c EEPROM : 

```
i2c1> [ 0xa0 0x00 [ 0xa1 hd:32 ]
I2C START
WRITE: 0xA0 ACK 0x00 ACK 
I2C START
WRITE: 0xA1 ACK 
5B 30 78 61 31 FF FF FF  42 00 75 00 80 08 00 01  |  [0xa1...B.u..... 
0E FF 0C 01 02 20 00 A0  75 00 00 50 3C 50 2D 20  |  ..... ..u..P<P-  
NACK
I2C STOP
```