### PR TITLE
Initial 1-wire support

### DIFF
--- a/common/exec.c
+++ b/common/exec.c
@@ -243,6 +243,7 @@ static struct cmd_map {
 	{ T_SUMP, cmd_sump },
 	{ T_JTAG, cmd_mode_init },
 	{ T_RNG, cmd_rng },
+	{ T_ONEWIRE, cmd_mode_init },
 	{ T_TWOWIRE, cmd_mode_init },
 	{ T_THREEWIRE, cmd_mode_init },
 	{ 0, NULL }

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -141,6 +141,7 @@ t_token_dict tl_dict[] = {
 	{ T_THREEWIRE, "3-wire" },
 	{ T_SCRIPT, "script" },
 	{ T_FILE, "filename" },
+	{ T_ONEWIRE, "1-wire" },
 
 	{ T_LEFT_SQ, "[" },
 	{ T_RIGHT_SQ, "]" },
@@ -879,6 +880,99 @@ t_token tokens_jtag[] = {
 	{ }
 };
 
+#define ONEWIRE_PARAMETERS \
+	{ T_DEVICE, \
+		.arg_type = T_ARG_UINT, \
+		.help = "1-wire device (1)" }, \
+	{ T_PULL, \
+		.arg_type = T_ARG_TOKEN, \
+		.subtokens = tokens_gpio_pull, \
+		.help = "GPIO pull (up/down/floating)" }, \
+	{ T_MSB_FIRST, \
+		.help = "Send/receive MSB first" }, \
+	{ T_LSB_FIRST, \
+		.help = "Send/receive LSB first" },
+
+t_token tokens_mode_onewire[] = {
+	{
+		T_SHOW,
+		.subtokens = tokens_mode_show,
+		.help = "Show 1-wire parameters"
+	},
+	ONEWIRE_PARAMETERS
+	/* 1-wire-specific commands */
+	{
+		T_SCAN,
+		.help = "Scan for connected devices"
+	},
+	{
+		T_READ,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>)"
+	},
+	{
+		T_HD,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Read byte (repeat with :<num>) and print hexdump"
+	},
+	{
+		T_WRITE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_ARG_UINT,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write byte (repeat with :<num>)"
+	},
+	{
+		T_ARG_STRING,
+		.help = "Write string"
+	},
+	/* BP commands */
+	{
+		T_LEFT_SQ,
+		.help = "Reset bus"
+	},
+	{
+		T_MINUS,
+		.help = "Toggle pin high"
+	},
+	{
+		T_UNDERSCORE,
+		.help = "Toggle pin low"
+	},
+	{
+		T_DOT,
+		.help = "Read bit"
+	},
+	{
+		T_AMPERSAND,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Delay 1 usec (repeat with :<num>)"
+	},
+	{
+		T_PERCENT,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Delay 1 msec (repeat with :<num>)"
+	},
+	{
+		T_TILDE,
+		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
+		.help = "Write a random byte (repeat with :<num>)"
+	},
+	{
+		T_EXIT,
+		.help = "Exit 1-wire mode"
+	},
+	{ }
+};
+
+t_token tokens_onewire[] = {
+	ONEWIRE_PARAMETERS
+	{ }
+};
+
 #define TWOWIRE_PARAMETERS \
 	{ T_DEVICE, \
 		.arg_type = T_ARG_UINT, \
@@ -1442,6 +1536,11 @@ t_token tl_tokens[] = {
 		.subtokens = tokens_i2c,
 		.help = "I2C mode",
 		.help_full = "Configuration: i2c [pull (up/down/floating)] [frequency (value hz/khz/mhz)]\r\nInteraction: [<start>] [<stop>] <read/write (value:repeat)>"
+	},
+	{
+		T_ONEWIRE,
+		.subtokens = tokens_onewire,
+		.help = "1-wire mode"
 	},
 	{
 		T_TWOWIRE,

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -134,6 +134,7 @@ enum {
 	T_THREEWIRE,
 	T_SCRIPT,
 	T_FILE,
+	T_ONEWIRE,
 
 	/* BP-compatible commands */
 	T_LEFT_SQ,

--- a/hydrabus/hydrabus.mk
+++ b/hydrabus/hydrabus.mk
@@ -12,6 +12,7 @@ HYDRABUSSRC = hydrabus/hydrabus.c \
             hydrabus/hydrabus_sump.c \
             hydrabus/hydrabus_mode_jtag.c \
             hydrabus/hydrabus_rng.c \
+            hydrabus/hydrabus_mode_onewire.c \
             hydrabus/hydrabus_mode_twowire.c \
             hydrabus/hydrabus_mode_threewire.c \
             hydrabus/hydrabus_mode_can.c \
@@ -22,7 +23,8 @@ HYDRABUSSRC = hydrabus/hydrabus.c \
             hydrabus/hydrabus_bbio_uart.c \
             hydrabus/hydrabus_bbio_i2c.c \
             hydrabus/hydrabus_bbio_rawwire.c \
-            hydrabus/hydrabus_freq.c
+            hydrabus/hydrabus_freq.c \
+            hydrabus/hydrabus_bbio_onewire.c
 
 # Required include directories
 HYDRABUSINC = ./hydrabus

--- a/hydrabus/hydrabus_bbio.c
+++ b/hydrabus/hydrabus_bbio.c
@@ -32,6 +32,7 @@
 #include "hydrabus_bbio_uart.h"
 #include "hydrabus_bbio_i2c.h"
 #include "hydrabus_bbio_rawwire.h"
+#include "hydrabus_bbio_onewire.h"
 
 int cmd_bbio(t_hydra_console *con)
 {
@@ -55,7 +56,7 @@ int cmd_bbio(t_hydra_console *con)
 				break;
 			case BBIO_1WIRE:
 				cprint(con, "1W01", 4);
-				//TODO
+				bbio_mode_onewire(con);
 				break;
 			case BBIO_RAWWIRE:
 				cprint(con, "RAW1", 4);

--- a/hydrabus/hydrabus_bbio.h
+++ b/hydrabus/hydrabus_bbio.h
@@ -124,4 +124,11 @@
 #define BBIO_RAWWIRE_SET_SPEED	0b01100000
 #define BBIO_RAWWIRE_CONFIG	0b10000000
 
+/*
+ * 1-Wire-specific commands
+ */
+#define BBIO_ONEWIRE_RESET	0b00000010
+#define BBIO_ONEWIRE_READ	0b00000100
+#define BBIO_ONEWIRE_BULK_TRANSFER 0b00010000
+
 int cmd_bbio(t_hydra_console *con);

--- a/hydrabus/hydrabus_bbio_onewire.c
+++ b/hydrabus/hydrabus_bbio_onewire.c
@@ -1,0 +1,68 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2014-2016 Benjamin VERNOUX
+ * Copyright (C) 2016 Nicolas OBERLI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common.h"
+#include "tokenline.h"
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "hydrabus_bbio.h"
+#include "hydrabus_bbio_onewire.h"
+#include "hydrabus_mode_onewire.h"
+
+
+void bbio_mode_onewire(t_hydra_console *con)
+{
+	uint8_t bbio_subcommand, i;
+	uint8_t rx_data[16], tx_data[16];
+	uint8_t data;
+
+	onewire_init_proto_default(con);
+	onewire_pin_init(con);
+
+	while (!USER_BUTTON) {
+		if(chnRead(con->sdu, &bbio_subcommand, 1) == 1) {
+			switch(bbio_subcommand) {
+			case BBIO_RESET:
+				onewire_cleanup(con);
+				return;
+			case BBIO_ONEWIRE_RESET:
+				onewire_start(con);
+			case BBIO_ONEWIRE_READ:
+				rx_data[0] = onewire_read_u8(con);
+				cprint(con, (char *)&rx_data[0], 1);
+				break;
+			default:
+				if ((bbio_subcommand & BBIO_ONEWIRE_BULK_TRANSFER) == BBIO_ONEWIRE_BULK_TRANSFER) {
+					// data contains the number of bytes to
+					// write
+					data = (bbio_subcommand & 0b1111) + 1;
+
+					chnRead(con->sdu, tx_data, data);
+					for(i=0; i<data; i++) {
+						onewire_write_u8(con, tx_data[i]);
+					}
+					cprint(con, "\x01", 1);
+				}
+			}
+		}
+	}
+	onewire_cleanup(con);
+}

--- a/hydrabus/hydrabus_bbio_onewire.h
+++ b/hydrabus/hydrabus_bbio_onewire.h
@@ -1,0 +1,19 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2016 Nicolas OBERLI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void bbio_mode_onewire(t_hydra_console *con);

--- a/hydrabus/hydrabus_mode.c
+++ b/hydrabus/hydrabus_mode.c
@@ -40,6 +40,7 @@ extern const mode_exec_t mode_i2c_exec;
 extern const mode_exec_t mode_uart_exec;
 extern const mode_exec_t mode_nfc_exec;
 extern const mode_exec_t mode_jtag_exec;
+extern const mode_exec_t mode_onewire_exec;
 extern const mode_exec_t mode_twowire_exec;
 extern const mode_exec_t mode_threewire_exec;
 extern const mode_exec_t mode_can_exec;
@@ -48,6 +49,7 @@ extern t_token tokens_mode_i2c[];
 extern t_token tokens_mode_uart[];
 extern t_token tokens_mode_nfc[];
 extern t_token tokens_mode_jtag[];
+extern t_token tokens_mode_onewire[];
 extern t_token tokens_mode_twowire[];
 extern t_token tokens_mode_threewire[];
 extern t_token tokens_mode_can[];
@@ -62,6 +64,7 @@ static struct {
 	{ T_UART, tokens_mode_uart, &mode_uart_exec },
 	{ T_NFC, tokens_mode_nfc, &mode_nfc_exec },
 	{ T_JTAG, tokens_mode_jtag, &mode_jtag_exec },
+	{ T_ONEWIRE, tokens_mode_onewire, &mode_onewire_exec },
 	{ T_TWOWIRE, tokens_mode_twowire, &mode_twowire_exec },
 	{ T_THREEWIRE, tokens_mode_threewire, &mode_threewire_exec },
 	{ T_CAN, tokens_mode_can, &mode_can_exec },

--- a/hydrabus/hydrabus_mode_onewire.c
+++ b/hydrabus/hydrabus_mode_onewire.c
@@ -1,0 +1,408 @@
+/*
+* HydraBus/HydraNFC
+*
+* Copyright (C) 2014-2015 Benjamin VERNOUX
+* Copyright (C) 2016 Nicolas OBERLI
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#include "common.h"
+#include "tokenline.h"
+#include "hydrabus.h"
+#include "bsp.h"
+#include "bsp_gpio.h"
+#include "hydrabus_mode_onewire.h"
+#include "stm32f4xx_hal.h"
+#include <string.h>
+
+static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
+static int show(t_hydra_console *con, t_tokenline_parsed *p);
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
+
+static const char* str_prompt_onewire[] = {
+	"onewire1" PROMPT,
+};
+
+void onewire_init_proto_default(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	/* Defaults */
+	proto->dev_num = 0;
+	proto->dev_gpio_mode = MODE_CONFIG_DEV_GPIO_OUT_OPENDRAIN;
+	proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_NOPULL;
+	proto->dev_bit_lsb_msb = DEV_SPI_FIRSTBIT_LSB;
+}
+
+static void show_params(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	cprintf(con, "Device: onewire%d\r\nGPIO resistor: %s\r\n",
+		proto->dev_num + 1,
+		proto->dev_gpio_pull == MODE_CONFIG_DEV_GPIO_PULLUP ? "pull-up" :
+		proto->dev_gpio_pull == MODE_CONFIG_DEV_GPIO_PULLDOWN ? "pull-down" :
+		"floating");
+
+	cprintf(con, "Bit order: %s first\r\n",
+		proto->dev_bit_lsb_msb == DEV_SPI_FIRSTBIT_MSB ? "MSB" : "LSB");
+}
+
+bool onewire_pin_init(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+
+	bsp_gpio_init(BSP_GPIO_PORTB, ONEWIRE_PIN,
+		      proto->dev_gpio_mode, proto->dev_gpio_pull);
+	return true;
+}
+
+static void onewire_mode_input(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	bsp_gpio_init(BSP_GPIO_PORTB, ONEWIRE_PIN,
+		      MODE_CONFIG_DEV_GPIO_IN, proto->dev_gpio_pull);
+}
+
+static void onewire_mode_output(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	bsp_gpio_init(BSP_GPIO_PORTB, ONEWIRE_PIN,
+		      proto->dev_gpio_mode, proto->dev_gpio_pull);
+}
+
+inline void onewire_high(void)
+{
+	bsp_gpio_set(BSP_GPIO_PORTB, ONEWIRE_PIN);
+}
+
+inline void onewire_low(void)
+{
+	bsp_gpio_clr(BSP_GPIO_PORTB, ONEWIRE_PIN);
+}
+
+void onewire_write_bit(t_hydra_console *con, uint8_t bit)
+{
+	onewire_mode_output(con);
+	onewire_low();
+	if(bit){
+		DelayUs(6);
+		onewire_high();
+		DelayUs(64);
+	}else{
+		DelayUs(60);
+		onewire_high();
+		DelayUs(10);
+	}
+}
+
+uint8_t onewire_read_bit(t_hydra_console *con)
+{
+	uint8_t bit=0;
+
+	onewire_mode_output(con);
+	onewire_low();
+	DelayUs(6);
+	onewire_high();
+	DelayUs(9);
+	onewire_mode_input(con);
+	bit = bsp_gpio_pin_read(BSP_GPIO_PORTB, ONEWIRE_PIN);
+	DelayUs(55);
+	return bit;
+}
+
+static void dath(t_hydra_console *con)
+{
+	onewire_high();
+	cprintf(con, "PIN HIGH\r\n");
+}
+
+static void datl(t_hydra_console *con)
+{
+	onewire_low();
+	cprintf(con, "PIN LOW\r\n");
+}
+
+static void bitr(t_hydra_console *con)
+{
+	uint8_t rx_data = onewire_read_bit(con);
+	cprintf(con, hydrabus_mode_str_read_one_u8, rx_data);
+}
+
+void onewire_start(t_hydra_console *con)
+{
+	onewire_mode_output(con);
+	onewire_low();
+	DelayUs(480);
+	onewire_high();
+	DelayUs(70);
+	onewire_mode_input(con);
+	// Can check for device presence here
+	DelayUs(410);
+
+}
+
+void onewire_write_u8(t_hydra_console *con, uint8_t tx_data)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	uint8_t i;
+
+	onewire_mode_output(con);
+
+	if(proto->dev_bit_lsb_msb == DEV_SPI_FIRSTBIT_LSB) {
+		for (i=0; i<8; i++) {
+			onewire_write_bit(con, (tx_data>>i) & 1);
+		}
+	} else {
+		for (i=0; i<8; i++) {
+			onewire_write_bit(con, (tx_data>>(7-i)) & 1);
+		}
+	}
+}
+
+uint8_t onewire_read_u8(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	uint8_t value;
+	uint8_t i;
+
+
+	value = 0;
+	if(proto->dev_bit_lsb_msb == DEV_SPI_FIRSTBIT_LSB) {
+		for(i=0; i<8; i++) {
+			value |= (onewire_read_bit(con) << i);
+		}
+	} else {
+		for(i=0; i<8; i++) {
+			value |= (onewire_read_bit(con) << (7-i));
+		}
+	}
+	return value;
+}
+
+void onewire_scan(t_hydra_console *con)
+{
+	uint8_t id_bit_number = 0;
+	uint8_t last_zero = 0;
+	uint8_t id_bit = 0, cmp_id_bit = 0;
+	uint8_t search_direction = 0;
+	uint8_t LastDiscrepancy = 0;
+	uint8_t LastDeviceFlag = 0;
+	uint8_t i;
+	uint8_t ROM_NO[8] = {0};
+	onewire_start(con);
+	onewire_write_u8(con, 0xf0);
+	cprintf(con, "Discovered devices : ");
+	while(!LastDeviceFlag) {
+		do{
+			id_bit = onewire_read_bit(con);
+			cmp_id_bit = onewire_read_bit(con);
+			if(id_bit && cmp_id_bit) {
+				break;
+			} else {
+				if (!id_bit && !cmp_id_bit) {
+					if (id_bit_number == LastDiscrepancy) {
+						search_direction = 1;
+					} else {
+						if (id_bit_number > LastDiscrepancy) {
+							search_direction = 0;
+						} else {
+							search_direction = 
+								(ROM_NO[id_bit_number/8]
+								& (id_bit_number%8))>0;
+						}
+					}
+					if(search_direction == 0) {
+						last_zero = id_bit_number;
+					}
+				} else {
+					search_direction = id_bit;
+				}
+			}
+			ROM_NO[id_bit_number/8] |= search_direction<<(id_bit_number%8);
+			onewire_write_bit(con, search_direction);
+			id_bit_number++;
+		}while(id_bit_number<64);
+		LastDiscrepancy = last_zero;
+		if (LastDiscrepancy == 0) {
+			LastDeviceFlag = true;
+		}
+		for(i=0; i<8; i++) {
+			cprintf(con, "%02X ", ROM_NO[i]);
+		}
+		cprintf(con, "\r\n");
+	}
+}
+
+static int init(t_hydra_console *con, t_tokenline_parsed *p)
+{
+	int tokens_used;
+
+	/* Defaults */
+	onewire_init_proto_default(con);
+
+	/* Process cmdline arguments, skipping "onewire". */
+	tokens_used = 1 + exec(con, p, 1);
+
+	onewire_pin_init(con);
+
+	onewire_low();
+
+	show_params(con);
+
+	return tokens_used;
+}
+
+static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	int arg_int, t;
+
+	for (t = token_pos; p->tokens[t]; t++) {
+		switch (p->tokens[t]) {
+		case T_SHOW:
+			t += show(con, p);
+			break;
+		case T_PULL:
+			switch (p->tokens[++t]) {
+			case T_UP:
+				proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_PULLUP;
+				break;
+			case T_DOWN:
+				proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_PULLDOWN;
+				break;
+			case T_FLOATING:
+				proto->dev_gpio_pull = MODE_CONFIG_DEV_GPIO_NOPULL;
+				break;
+			}
+			onewire_pin_init(con);
+			break;
+		case T_HD:
+			/* Integer parameter. */
+			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
+				t += 2;
+				memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+			} else {
+				arg_int = 1;
+			}
+			dump(con, proto->buffer_rx, arg_int);
+			break;
+		case T_MSB_FIRST:
+			proto->dev_bit_lsb_msb = DEV_SPI_FIRSTBIT_MSB;
+			break;
+		case T_LSB_FIRST:
+			proto->dev_bit_lsb_msb = DEV_SPI_FIRSTBIT_LSB;
+			break;
+		case T_SCAN:
+			onewire_scan(con);
+			break;
+		default:
+			return t - token_pos;
+		}
+	}
+
+	return t - token_pos;
+}
+
+static uint32_t write(t_hydra_console *con, uint8_t *tx_data, uint8_t nb_data)
+{
+	int i;
+	for (i = 0; i < nb_data; i++) {
+		onewire_write_u8(con, tx_data[i]);
+	}
+	if(nb_data == 1) {
+		/* Write 1 data */
+		cprintf(con, hydrabus_mode_str_write_one_u8, tx_data[0]);
+	} else if(nb_data > 1) {
+		/* Write n data */
+		cprintf(con, hydrabus_mode_str_mul_write);
+		for(i = 0; i < nb_data; i++) {
+			cprintf(con, hydrabus_mode_str_mul_value_u8,
+				tx_data[i]);
+		}
+		cprintf(con, hydrabus_mode_str_mul_br);
+	}
+	return BSP_OK;
+}
+
+static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+{
+	int i;
+
+	for(i = 0; i < nb_data; i++) {
+		rx_data[i] = onewire_read_u8(con);
+	}
+	if(nb_data == 1) {
+		/* Read 1 data */
+		cprintf(con, hydrabus_mode_str_read_one_u8, rx_data[0]);
+	} else if(nb_data > 1) {
+		/* Read n data */
+		cprintf(con, hydrabus_mode_str_mul_read);
+		for(i = 0; i < nb_data; i++) {
+			cprintf(con, hydrabus_mode_str_mul_value_u8,
+				rx_data[i]);
+		}
+		cprintf(con, hydrabus_mode_str_mul_br);
+	}
+	return BSP_OK;
+}
+
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+{
+	int i;
+
+	for(i = 0; i < nb_data; i++) {
+		rx_data[i] = onewire_read_u8(con);
+	}
+	print_hex(con, rx_data, nb_data);
+	return BSP_OK;
+}
+
+void onewire_cleanup(t_hydra_console *con)
+{
+	(void)con;
+}
+
+static int show(t_hydra_console *con, t_tokenline_parsed *p)
+{
+	int tokens_used;
+
+	tokens_used = 0;
+	if (p->tokens[1] == T_PINS) {
+		tokens_used++;
+		cprintf(con, "PIN: PB%d\r\n", ONEWIRE_PIN);
+	} else {
+		show_params(con);
+	}
+	return tokens_used;
+}
+
+static const char *get_prompt(t_hydra_console *con)
+{
+	mode_config_proto_t* proto = &con->mode->proto;
+	return str_prompt_onewire[proto->dev_num];
+}
+
+const mode_exec_t mode_onewire_exec = {
+	.init = &init,
+	.exec = &exec,
+	.write = &write,
+	.read = &read,
+	.cleanup = &onewire_cleanup,
+	.get_prompt = &get_prompt,
+	.dath = &dath,
+	.datl = &datl,
+	.bitr = &bitr,
+	.start = &onewire_start,
+};
+

--- a/hydrabus/hydrabus_mode_onewire.h
+++ b/hydrabus/hydrabus_mode_onewire.h
@@ -1,0 +1,41 @@
+/*
+* HydraBus/HydraNFC
+*
+* Copyright (C) 2015 Benjamin VERNOUX
+* Copyright (C) 2016 Nicolas OBERLI
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "hydrabus_mode.h"
+
+#define ONEWIRE_PIN	 11
+
+/* OneWire commands */
+#define ONEWIRE_CMD_READROM			0x33
+#define ONEWIRE_CMD_MATCHROM			0x55
+#define ONEWIRE_CMD_SEARCHROM			0xF0
+#define ONEWIRE_CMD_SKIPROM			0xCC
+
+
+void onewire_init_proto_default(t_hydra_console *con);
+bool onewire_pin_init(t_hydra_console *con);
+uint8_t onewire_read_u8(t_hydra_console *con);
+void onewire_write_u8(t_hydra_console *con, uint8_t tx_data);
+inline void onewire_low(void);
+inline void onewire_high(void);
+void onewire_send_bit(t_hydra_console *con, uint8_t bit);
+uint8_t onewire_read_bit(t_hydra_console *con);
+void onewire_cleanup(t_hydra_console *con);
+void onewire_start(t_hydra_console *con);
+void onewire_scan(t_hydra_console *con);


### PR DESCRIPTION
Support for 1-wire protocol (https://www.maximintegrated.com/en/products/digital/one-wire.html)

- All the basic console commands supported
- `scan` command scans the 1-wire bus to locate devices
- BBIO 1-wire mode