### PR TITLE
Change maximum size of hexdump command

### DIFF
--- a/hydrabus/hydrabus_mode_onewire.c
+++ b/hydrabus/hydrabus_mode_onewire.c
@@ -27,7 +27,7 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data);
 
 static const char* str_prompt_onewire[] = {
 	"onewire1" PROMPT,
@@ -266,7 +266,8 @@ static int init(t_hydra_console *con, t_tokenline_parsed *p)
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
-	int arg_int, t;
+	uint32_t arg_u32;
+	int t;
 
 	for (t = token_pos; p->tokens[t]; t++) {
 		switch (p->tokens[t]) {
@@ -291,11 +292,11 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			/* Integer parameter. */
 			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
 				t += 2;
-				memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+				memcpy(&arg_u32, p->buf + p->tokens[t], sizeof(uint32_t));
 			} else {
-				arg_int = 1;
+				arg_u32 = 1;
 			}
-			dump(con, proto->buffer_rx, arg_int);
+			dump(con, proto->buffer_rx, arg_u32);
 			break;
 		case T_MSB_FIRST:
 			proto->dev_bit_lsb_msb = DEV_SPI_FIRSTBIT_MSB;
@@ -357,14 +358,26 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data)
 {
-	int i;
+	uint32_t bytes_read = 0;
+	uint8_t i, to_rx;
 
-	for(i = 0; i < nb_data; i++) {
-		rx_data[i] = onewire_read_u8(con);
+	while(bytes_read < nb_data){
+		/* using 240 to stay aligned in hexdump */
+		if((nb_data-bytes_read) >= 240) {
+			to_rx = 240;
+		} else {
+			to_rx = (nb_data-bytes_read);
+		}
+
+		for(i = 0; i < to_rx; i++) {
+			rx_data[i] = onewire_read_u8(con);
+		}
+		print_hex(con, rx_data, to_rx);
+
+		bytes_read += to_rx;
 	}
-	print_hex(con, rx_data, nb_data);
 	return BSP_OK;
 }
 

--- a/hydrabus/hydrabus_mode_twowire.c
+++ b/hydrabus/hydrabus_mode_twowire.c
@@ -27,7 +27,7 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data);
 
 static twowire_config config;
 static TIM_HandleTypeDef htim;
@@ -280,7 +280,8 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
 	float arg_float;
-	int arg_int, t;
+	uint32_t arg_u32;
+	int t;
 
 	for (t = token_pos; p->tokens[t]; t++) {
 		switch (p->tokens[t]) {
@@ -321,11 +322,11 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			/* Integer parameter. */
 			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
 				t += 2;
-				memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+				memcpy(&arg_u32, p->buf + p->tokens[t], sizeof(uint32_t));
 			} else {
-				arg_int = 1;
+				arg_u32 = 1;
 			}
-			dump(con, proto->buffer_rx, arg_int);
+			dump(con, proto->buffer_rx, arg_u32);
 			break;
 		default:
 			return t - token_pos;
@@ -378,14 +379,26 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data)
 {
-	int i;
+	uint32_t bytes_read = 0;
+	uint8_t i, to_rx;
 
-	for(i = 0; i < nb_data; i++) {
-		rx_data[i] = twowire_read_u8(con);
+	while(bytes_read < nb_data){
+		/* using 240 to stay aligned in hexdump */
+		if((nb_data-bytes_read) >= 240) {
+			to_rx = 240;
+		} else {
+			to_rx = (nb_data-bytes_read);
+		}
+
+		for(i = 0; i < to_rx; i++) {
+			rx_data[i] = twowire_read_u8(con);
+		}
+		print_hex(con, rx_data, to_rx);
+
+		bytes_read += to_rx;
 	}
-	print_hex(con, rx_data, nb_data);
 	return BSP_OK;
 }
 


### PR DESCRIPTION
Now the `hd` command can accept a 32-bit unsigned number.
Now up to 4294967295 bytes can be read at once